### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:
@@ -36,6 +38,9 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      pull-requests: write
     
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/sandbox-npm-package/security/code-scanning/1](https://github.com/RumenDamyanov/sandbox-npm-package/security/code-scanning/1)

To fix the problem, we should add a top-level `permissions` block to `.github/workflows/ci.yml` specifying the least privilege required for the overall workflow. For most jobs here (`lint`, `test`, `build`, `security`), only read access to repository contents is necessary (`contents: read`). For jobs needing additional permissions—specifically the Coverage PR Comment step in `test`—the job can be given a permissions override (`pull-requests: write` in addition to `contents: read`).  
**Steps:**  
1. At the root of the workflow file (after the `name:` field and before `on:`), add:
   ```yaml
   permissions:
     contents: read
   ```
   This sets all jobs to least privilege by default.
2. For the `test` job, only the PR comment step via `marocchino/sticky-pull-request-comment@v2` actually needs write access to pull requests. To keep permissions tightest, set its job-level permissions to:
   ```yaml
   permissions:
     contents: read
     pull-requests: write
   ```
   (GitHub only supports job-level granularity, not step-level, so we need this for the whole `test` job.)

No new imports or dependencies are needed; these are configuration changes to the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
